### PR TITLE
Restrict ZFS list to chosen pool

### DIFF
--- a/docs/manual/SCALE Apps/backup-restore.md
+++ b/docs/manual/SCALE Apps/backup-restore.md
@@ -96,7 +96,7 @@ Do not choose an apps pool yet, or do ANYTHING with apps until step 3
 
 >
 ```bash
-zfs set mountpoint=legacy "$(zfs list -t filesystem -r "$(cli -c 'app kubernetes config' | grep -E "pool\s\|" | awk -F '|' '{print $3}' | tr -d " \t\n\r")" -o name -H | grep "pvc")" 
+zfs set mountpoint=legacy "$(zfs list -t filesystem -r "$(cli -c 'app kubernetes config' | grep -E "pool\s\|" | awk -F '|' '{print $3}' | tr -d " \t\n\r")" -o name -H | grep "volumes/pvc")" 
 ```
 
 5. That's pretty much it, now all you need to do is restore the Truetool snapshot of your `ix-applications` dataset by following the [Reverting a running system](#reverting-a-running-system) guide above.

--- a/docs/manual/SCALE Apps/backup-restore.md
+++ b/docs/manual/SCALE Apps/backup-restore.md
@@ -96,7 +96,7 @@ Do not choose an apps pool yet, or do ANYTHING with apps until step 3
 
 >
 ```bash
-zfs set mountpoint=legacy $(zfs list -o name | grep ix-applications | grep pvc) 
+zfs set mountpoint=legacy "$(zfs list -t filesystem -r "$(cli -c 'app kubernetes config' | grep -E "pool\s\|" | awk -F '|' '{print $3}' | tr -d " \t\n\r")" -o name -H | grep "pvc")" 
 ```
 
 5. That's pretty much it, now all you need to do is restore the Truetool snapshot of your `ix-applications` dataset by following the [Reverting a running system](#reverting-a-running-system) guide above.


### PR DESCRIPTION
Search only for PVC from the pool the user selected in step 3
- This will prevent errors with users having multiple `ix-applications` datasets on their system.

Testing:
Tested on my VM, Before choosing a pool tossed an error (as expected), after choosing a pool, the command seemed to have gone through, so long as zfs set mountpoint=legacy does not output anything on its success. So, I am assuming it worked. May require further testing

Also counted the PVC's from both the previous command and this one, to ensure the same amount of PVC's were getting picked up, they were. 

Signed-off-by: Heavybullets8 <heavybullets8@gmail.com>
